### PR TITLE
Added support for providing field name overrides when reading and writing JSON documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+protobuf-codec.i*

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@ http://maven.apache.org/maven-v4_0_0.xsd">
 		<module>protobuf-codec-core</module>
 		<module>protobuf-codec-json</module>
 		<module>protobuf-codec-xml</module>
+        <module>protobuf-codec-text</module>
 	</modules>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ http://maven.apache.org/maven-v4_0_0.xsd">
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>2.3.0</version>
+			<version>2.4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>

--- a/protobuf-codec-core/.gitignore
+++ b/protobuf-codec-core/.gitignore
@@ -1,1 +1,2 @@
 /target
+protobuf-codec-core.iml

--- a/protobuf-codec-core/src/main/java/protobuf/codec/Codec.java
+++ b/protobuf-codec-core/src/main/java/protobuf/codec/Codec.java
@@ -38,12 +38,12 @@ public interface Codec {
 	 * Write this Message {@link Message} to the provided output stream. The underlying stream is not closed by default, 
 	 * user {@link Feature#CLOSE_STREAM} for the required settings.
 	 * The default values are not written out, the reason being that the client should be aware of the protobuf schema.
-	 * The {@link UnknownFieldSet} are written out on whether the {@link Feature#UNKNOWN_FIELDS} is set. By default, {@link UnknownFieldSet}
+	 * The {@link UnknownFieldSet} are written out on whether the {@link Feature#UNKNOWN_FIELD_ELEM_NAME} is set. By default, {@link UnknownFieldSet}
 	 * is written out Check the codec implementation on how the unknown field set is written out.
 	 * Extension fields are written out and the naming depends on the {@link Feature#EXTENSION_FIELD_NAME_PREFIX} set. 
 	 * If an extension field  not provided in the registry is encountered that field is skipped.
 	 * @param message the {@link Message}
-	 * @param os the output stream
+	 * @param writer the output stream writer
 	 * @throws IOException
 	 * @throws IllegalArgumentException if the provided message is not initialized 
 	 */
@@ -55,12 +55,12 @@ public interface Codec {
 	 * In case null values encountered are skipped since protobuf does not support null values yet 
 	 * ( http://code.google.com/p/protobuf/issues/detail?id=57 )
 	 * The default values are not written out, the reason being that the client should be aware of the protobuf schema.
-	 * The {@link UnknownFieldSet} are read in depending on whether the {@link Feature#UNKNOWN_FIELDS} is set. By default, {@link UnknownFieldSet}
+	 * The {@link UnknownFieldSet} are read in depending on whether the {@link Feature#UNKNOWN_FIELD_ELEM_NAME} is set. By default, {@link UnknownFieldSet}
 	 * is read in. Check the codec implementation on how the unknown field need to be passed in.
 	 * Extension field names depend on {@link Feature#EXTENSION_FIELD_NAME_PREFIX}
 	 * If an extension field  not provided in the registry is encountered that field is skipped.
 	 * @param messageType the {@link Class} corresponding to the {@link Message} the stream needs to be read into
-	 * @param in the input stream
+	 * @param reader the input stream reader
 	 * @return the {@link Message}
 	 * @throws IOException
 	 */
@@ -76,7 +76,7 @@ public interface Codec {
 	 * is identified to be an extension field, but a corresponding mapping is not found in the registry, then 
 	 * the field is skipped.
 	 * @param messageType the {@link Class} corresponding to the {@link Message} the stream needs to be read into
-	 * @param in the input stream
+	 * @param reader the input stream reader
 	 * @param extnRegistry the extension registry which contains the defn for extension fields.
 	 * @return the {@link Message}
 	 * @throws IOException
@@ -114,7 +114,7 @@ public interface Codec {
 	 * @param extnRegistry the extension registry
 	 * @return
 	 * @throws IOException
-	 * @see {@link #toMessage(Reader)}
+	 * @see {@link #toMessage(Class, Reader)}
 	 */
 	<T extends Message> T toMessage(Class<T> messageType,InputStream in,ExtensionRegistry extnRegistry) throws IOException;
 	
@@ -162,6 +162,11 @@ public interface Codec {
 		/** Unknown field element name */
 		UNKNOWN_FIELD_ELEM_NAME,
 		/** Extension field name prefix */
-		EXTENSION_FIELD_NAME_PREFIX;
+		EXTENSION_FIELD_NAME_PREFIX,
+        /** Strip leading and trailing underscores from field names */
+        STRIP_FIELD_NAME_UNDERSCORES,
+        /** Provide field name substitutes for reading and writing from/to a protobuf stream*/
+        FIELD_NAME_READ_SUBSTITUTES,
+        FIELD_NAME_WRITE_SUBSTITUTES;
 	}
 }

--- a/protobuf-codec-json/.gitignore
+++ b/protobuf-codec-json/.gitignore
@@ -1,2 +1,2 @@
 /target
-/target
+protobuf-codec-json.iml

--- a/protobuf-codec-json/src/main/java/protobuf/codec/json/JacksonJsonReader.java
+++ b/protobuf-codec-json/src/main/java/protobuf/codec/json/JacksonJsonReader.java
@@ -49,6 +49,8 @@ public class JacksonJsonReader {
 			JsonToken currToken = parser.getCurrentToken();
 			assert (currToken.equals(JsonToken.FIELD_NAME));
 			String fieldName = parser.getCurrentName();
+            fieldName = AbstractCodec.stripFieldName(fieldName, featureMap);
+            fieldName = AbstractCodec.substituteFieldNameForReading(fieldName, featureMap);
 			FieldDescriptor field=null;
 			if(JsonCodec.isExtensionFieldName(fieldName,featureMap)){
 				fieldName=JsonCodec.parseExtensionFieldName(fieldName,featureMap);

--- a/protobuf-codec-json/src/main/java/protobuf/codec/json/JacksonJsonWriter.java
+++ b/protobuf-codec-json/src/main/java/protobuf/codec/json/JacksonJsonWriter.java
@@ -43,6 +43,7 @@ public class JacksonJsonWriter {
 			Map.Entry<FieldDescriptor, Object> record = iterator.next();
 			FieldDescriptor field = record.getKey();
 			String fieldName = field.isExtension() ?JsonCodec.getExtensionFieldName(field.getName(),featureMap): field.getName(); // If extn field? box
+            fieldName = AbstractCodec.substituteFieldNameForWriting(fieldName, featureMap);
 			Object value = record.getValue();
 			if (field.isRepeated()) {
 				generator.writeArrayFieldStart(fieldName);

--- a/protobuf-codec-text/.gitignore
+++ b/protobuf-codec-text/.gitignore
@@ -1,0 +1,2 @@
+/target
+protobuf-codec-text.iml

--- a/protobuf-codec-text/pom.xml
+++ b/protobuf-codec-text/pom.xml
@@ -1,0 +1,74 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>protobuf</groupId>
+		<artifactId>protobuf-codec</artifactId>
+		<version>1.1</version>
+	</parent>
+	<artifactId>protobuf-codec-text</artifactId>
+	<packaging>jar</packaging>
+	<name>text codec</name>
+	<url>https://github.com/sijuv/protobuf-codec</url>
+	<dependencies>
+		<dependency>
+			<groupId>protobuf</groupId>
+			<artifactId>protobuf-codec-core</artifactId>
+			<version>1.1</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>generate-sources</id>
+						<phase>process-test-resources</phase>
+						<configuration>
+							<tasks>
+								<exec executable="protoc">
+									<arg value="--java_out=src/test/java" />
+									<arg value="src/test/resources/user.proto" />
+								</exec>
+							</tasks>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>generate-sources1</id>
+						<phase>process-test-resources</phase>
+						<configuration>
+							<tasks>
+								<exec executable="protoc">
+									<arg value="--java_out=src/test/java" />
+									<arg value="src/test/resources/unknown.proto" />
+								</exec>
+							</tasks>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>1.5</source>
+					<target>1.5</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/protobuf-codec-text/src/main/java/protobuf/codec/text/TextCodec.java
+++ b/protobuf-codec-text/src/main/java/protobuf/codec/text/TextCodec.java
@@ -1,0 +1,30 @@
+package protobuf.codec.text;
+
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.Message;
+import com.google.protobuf.TextFormat;
+import protobuf.codec.AbstractCodec;
+
+import java.io.*;
+
+/**
+ * User: aantonov
+ * Date: 7/21/11
+ */
+public class TextCodec extends AbstractCodec {
+    @Override
+    protected void writeToStream(Message message, Writer writer) throws IOException {
+        TextFormat.print(message, writer);
+    }
+
+    @Override
+    protected Message readFromStream(Message.Builder builder, Reader reader, ExtensionRegistry extnRegistry) throws IOException {
+        TextFormat.merge(reader, extnRegistry, builder);
+        return builder.build();
+    }
+
+    @Override
+    protected void validateAndSetFeature(Feature feature, Object value) {
+        // The features don't really matter, since there is no way to set any options to the Google's provided TextFormat
+    }
+}

--- a/protobuf-codec-text/src/test/java/protobuf/codec/text/.gitignore
+++ b/protobuf-codec-text/src/test/java/protobuf/codec/text/.gitignore
@@ -1,0 +1,2 @@
+/UnknownProtoBuf.java
+/TypesProtoBuf.java

--- a/protobuf-codec-text/src/test/java/protobuf/codec/text/TextCodecTest.java
+++ b/protobuf-codec-text/src/test/java/protobuf/codec/text/TextCodecTest.java
@@ -1,0 +1,68 @@
+package protobuf.codec.text;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.protobuf.ByteString;
+import org.junit.Test;
+import protobuf.codec.Codec;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+/**
+ * User: aantonov
+ * Date: 7/21/11
+ */
+public class TextCodecTest {
+
+    @Test
+    public void testBasics() throws Exception {
+        TypesProtoBuf.Types types = TypesProtoBuf.Types.newBuilder()
+				.setIdbool(true)
+				.setIddouble(Double.MAX_VALUE)
+				.setIdfixed32(Integer.MIN_VALUE)
+				.setIdfixed64(Long.MIN_VALUE)
+				.setIdfloat(Float.MAX_VALUE)
+				.setIdint32(1)
+				.setIdint64(5000000000000000000l)
+				.setIdsfixed32(-56)
+				.setIdsfixed64(-561234561435l)
+				.setIdsint32(-100)
+				.setIdsint64(Long.MAX_VALUE)
+				.setIdstring("Hello World")
+				.setIduint32(100)
+				.setIduint64(100l)
+				.setLang(TypesProtoBuf.Lang.HASKELL)
+				.setIdbyte(ByteString.copyFromUtf8("HelloWorld"))
+				.build();
+
+        StringWriter data = new StringWriter();
+        data.append("idstring: \"Hello World\"\n" +
+                "idint32: 1\n" +
+                "iddouble: 1.7976931348623157E308\n" +
+                "idfloat: 3.4028235E38\n" +
+                "idint64: 5000000000000000000\n" +
+                "iduint32: 100\n" +
+                "iduint64: 100\n" +
+                "idsint32: -100\n" +
+                "idsint64: 9223372036854775807\n" +
+                "idfixed32: 2147483648\n" +
+                "idfixed64: 9223372036854775808\n" +
+                "idsfixed32: -56\n" +
+                "idsfixed64: -561234561435\n" +
+                "idbool: true\n" +
+                "lang: HASKELL\n" +
+                "idbyte: \"HelloWorld\"\n");
+        data.flush();
+
+        StringWriter writer = new StringWriter();
+        Codec textCodec = new TextCodec();
+        textCodec.fromMessage(types, writer);
+
+        assertEquals(data.toString(), writer.toString());
+
+        TypesProtoBuf.Types msg = textCodec.toMessage(TypesProtoBuf.Types.class, new StringReader(writer.toString()));
+
+        assertEquals(types, msg);
+    }
+}

--- a/protobuf-codec-text/src/test/resources/unknown.proto
+++ b/protobuf-codec-text/src/test/resources/unknown.proto
@@ -1,0 +1,22 @@
+option java_package = "protobuf.codec.text";
+option java_outer_classname = "UnknownProtoBuf";
+
+message Unknown{
+	optional string name=1;
+	repeated Version verions=4;
+	extensions 100 to 200;
+}
+
+message Version{
+	optional string name=1;
+}
+
+enum Lang{
+	JAVA=1;
+	HASKELL=2;
+}
+
+extend Unknown{
+	optional int32 otherid=101;
+	repeated Lang lang=102;
+}

--- a/protobuf-codec-text/src/test/resources/user.proto
+++ b/protobuf-codec-text/src/test/resources/user.proto
@@ -1,0 +1,72 @@
+option java_package = "protobuf.codec.text";
+option java_outer_classname = "TypesProtoBuf";
+
+message Types{
+	optional string idstring = 1;
+	optional  int32 idint32 = 2;
+	optional  double iddouble = 3;
+	optional  float idfloat = 4;
+	optional  int64 idint64 = 5;
+	optional  uint32 iduint32 = 6;
+	optional  uint64 iduint64 = 7;
+	optional sint32 idsint32 = 8;
+	optional  sint64 idsint64 = 9;
+	optional  fixed32 idfixed32 = 10;
+	optional  fixed64 idfixed64 = 11;
+	optional  sfixed32 idsfixed32 = 12;
+	optional  sfixed64 idsfixed64 = 13;
+	optional  bool idbool = 14;
+	optional Lang lang=15;
+	optional bytes idbyte=16;
+	}
+	
+	
+message RepeatedFields{
+	required int32 fieldId=1;
+	repeated int32 id=2;
+	repeated string names=3;
+	repeated Version versions=4;
+	repeated Lang langs=5;
+}
+
+enum Lang{
+	JAVA=1;
+	HASKELL=2;
+}
+
+message Version{
+	optional string name=1;
+	optional int32 vernum=2;
+}
+
+message Foo{
+	optional int32 id=1;
+	optional string name=2;
+	extensions 100 to 200;
+}
+
+extend Foo{
+	optional string alias =100;
+    repeated Lang langs=101;
+    repeated Version version=102;
+    optional Version version1=103;
+}
+message Unknown{
+	optional string name=1;
+	optional int32 id=2;
+	repeated string alias =3;
+	repeated Version verions=4;
+	optional Version liveversion=5;
+	extensions 100 to 200;
+}
+
+extend Unknown{
+	optional string othername =100;
+	optional int32 otherid=101;
+	repeated Lang lang=102;
+	optional Version extversion=103;
+	repeated Version extversions=104;
+}
+
+
+

--- a/protobuf-codec-xml/.gitignore
+++ b/protobuf-codec-xml/.gitignore
@@ -1,1 +1,2 @@
 /target
+protobuf-codec-xml.iml


### PR DESCRIPTION
Hello Siju,

I've added a small enhancement to the framework in a form of allowing to set field alias replacements for both writing and reading from the JSON stream.  This is useful if you want to transform an existing/legacy JSON document to/from your new shiny proto model, as well as working with CouchDB, which has a convention of naming certain fields with and underscore, i.e __id_, __rev_, etc.

Hopefully you'll find this code adequate and acceptable to be pulled into the main branch.

Thanks,
Alex
alex@antonov.ws
