### PR TITLE
Pretty-printing fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ http://maven.apache.org/maven-v4_0_0.xsd">
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <version>1.6.2</version>
+            <version>1.9.12</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/protobuf-codec-json/pom.xml
+++ b/protobuf-codec-json/pom.xml
@@ -21,7 +21,7 @@ http://maven.apache.org/maven-v4_0_0.xsd">
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <version>1.6.2</version>
+            <version>1.9.12</version>
         </dependency>
     </dependencies>
     <build>

--- a/protobuf-codec-json/src/main/java/protobuf/codec/json/JacksonJsonWriter.java
+++ b/protobuf-codec-json/src/main/java/protobuf/codec/json/JacksonJsonWriter.java
@@ -28,15 +28,6 @@ public class JacksonJsonWriter {
 
     public static void generateJSONFields(Message message, JsonGenerator generator, Map<Feature, Object> featureMap) throws IOException {
 
-        generator.configure(org.codehaus.jackson.JsonGenerator.Feature.AUTO_CLOSE_TARGET, (Boolean) featureMap.get(Feature.CLOSE_STREAM));
-
-        if (AbstractCodec.prettyPrint(featureMap)) {
-            generator.useDefaultPrettyPrinter();
-        }
-        if (!AbstractCodec.closeStream(featureMap)) {
-            generator.configure(org.codehaus.jackson.JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
-        }
-
         generator.writeStartObject();
         Iterator<Map.Entry<FieldDescriptor, Object>> iterator = message.getAllFields().entrySet().iterator(); // Get all set fields
         while (iterator.hasNext()) {

--- a/protobuf-codec-json/src/main/java/protobuf/codec/json/JsonCodec.java
+++ b/protobuf-codec-json/src/main/java/protobuf/codec/json/JsonCodec.java
@@ -69,7 +69,16 @@ public class JsonCodec extends AbstractCodec {
     protected void writeToStream(Message message, Writer writer) throws IOException {
         JsonFactory jsonFactory = new JsonFactory();
         JsonGenerator generator = jsonFactory.createJsonGenerator(writer);
-        JacksonJsonWriter.generateJSONFields(message, generator, getAllFeaturesSet());
+
+        Map<Feature, Object> featureMap = getAllFeaturesSet();
+        generator.configure(org.codehaus.jackson.JsonGenerator.Feature.AUTO_CLOSE_TARGET, (Boolean) featureMap.get(Feature.CLOSE_STREAM));
+        if (AbstractCodec.prettyPrint(featureMap)) {
+            generator.useDefaultPrettyPrinter();
+        }
+        if (!AbstractCodec.closeStream(featureMap)) {
+            generator.configure(org.codehaus.jackson.JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
+        }
+        JacksonJsonWriter.generateJSONFields(message, generator, featureMap);
         generator.close();
     }
 


### PR DESCRIPTION
Bump jackson-core-asl dependency to avoid ArrayIndexOutOfBoundsException when pretty-printing certain structures. Move generator instantiation outwards to allow pretty-printing to maintain correct indentation prefix for nested structures.
